### PR TITLE
Add labels to wavefunctions in the proj output files

### DIFF
--- a/PP/src/projections_mod.f90
+++ b/PP/src/projections_mod.f90
@@ -11,6 +11,7 @@ MODULE projections
   TYPE wfc_label
      INTEGER na, n, l, m, ind
      REAL (DP) jj
+     CHARACTER(LEN=2) els
   END TYPE wfc_label
   TYPE(wfc_label), ALLOCATABLE :: nlmchi(:)
   
@@ -61,6 +62,7 @@ MODULE projections
                            nlmchi(nwfc)%m  =  m
                            nlmchi(nwfc)%ind  =  ind
                            nlmchi(nwfc)%jj  =  jj
+                           nlmchi(nwfc)%els = upf(nt)%els(n)
                         ENDIF
                      ENDDO
                   ELSE
@@ -81,6 +83,7 @@ MODULE projections
                                  nlmchi(nwfc)%m  =  m
                                  nlmchi(nwfc)%ind  =  ind
                                  nlmchi(nwfc)%jj  =  jj
+                                 nlmchi(nwfc)%els = upf(nt)%els(n)
                               ENDIF
                            ENDDO
                         ENDIF
@@ -95,6 +98,7 @@ MODULE projections
                      nlmchi(nwfc)%m  =  m
                      nlmchi(nwfc)%ind=  m
                      nlmchi(nwfc)%jj =  0.d0
+                     nlmchi(nwfc)%els = upf(nt)%els(n)
                   ENDDO
                   IF ( noncolin) THEN
                      DO m = 1, 2 * l + 1
@@ -105,6 +109,7 @@ MODULE projections
                         nlmchi(nwfc)%m  =  m
                         nlmchi(nwfc)%ind=  m+2*l+1
                         nlmchi(nwfc)%jj =  0.d0
+                        nlmchi(nwfc)%els = upf(nt)%els(n)
                      END DO
                   ENDIF
                ENDIF

--- a/PP/src/projwfc.f90
+++ b/PP/src/projwfc.f90
@@ -569,9 +569,9 @@ SUBROUTINE projwave( filproj, lsym, lwrite_ovp, lbinary )
                 dfftp%nr1, dfftp%nr2, dfftp%nr3, nat, ntyp, ibrav, celldm, at, gcutm, dual,   &
                 ecutwfc, nkstot/nspin, nbnd, natomwfc)
            DO nwfc = 1, natomwfc
-              WRITE(iunproj,'(2i5,1x,a4,3i5)') &
+              WRITE(iunproj,'(2i5,1x,a4,1x,a2,1x,3i5)') &
                   nwfc, nlmchi(nwfc)%na, atm(ityp(nlmchi(nwfc)%na)), &
-                  nlmchi(nwfc)%n, nlmchi(nwfc)%l, nlmchi(nwfc)%m
+                  nlmchi(nwfc)%els, nlmchi(nwfc)%n, nlmchi(nwfc)%l, nlmchi(nwfc)%m
               DO ik=nksinit,nkslast
                  DO ibnd=1,nbnd
                    WRITE(iunproj,'(2i8,f20.10)') ik,ibnd, &


### PR DESCRIPTION
Example output:
```
   F    F
    1    1  Fe  3S     1    0    1
       1       1        0.7928887359
       1       2        0.1587271885
       1       3        0.0000000000
       1       4        0.0000000000
       1       5        0.0000000000
       1       6        0.0000000000
       1       7        0.0000195778
       1       8        0.0000798979
       1       9        0.0163950400
       1      10        0.0000000007
```

This allows parsing correct n quantum number from the proj out file. It probably a good idea to squash this into one commit and merge.