### PR TITLE
Don't fail if symmetry changed during (vc) relax

### DIFF
--- a/PW/src/symm_base.f90
+++ b/PW/src/symm_base.f90
@@ -910,8 +910,8 @@ SUBROUTINE checkallsym ( nat, tau, ityp )
   IF (any (.not.loksym (1:nsym) ) ) THEN
       !call symmetrize_at (nsym, s, invs, ft, irt, nat, tau, at, bg, &
       !                    alat, omega)
-      CALL errore ('checkallsym', &
-           'some of the original symmetry operations not satisfied ',1)
+      CALL infomsg ('checkallsym', &
+           'some of the original symmetry operations not satisfied ')
   ENDIF
   !
   RETURN


### PR DESCRIPTION
Example is attached ([vc-relax-with-symm-constraints.tar.gz](https://github.com/QEF/q-e_schrodinger/files/842238/vc-relax-with-symm-constraints.tar.gz)). File '*-WORKED.out' contains output using patched version.

I don't know if this is a right thing to do. For me, if I submit a symmetric structure for a (vc) relax, I expect that symmetry might change in the final structure.