### PR TITLE
Parse orbital labels from GIPAW if needed for PDOS

### DIFF
--- a/PP/src/projections_mod.f90
+++ b/PP/src/projections_mod.f90
@@ -46,6 +46,10 @@ MODULE projections
          DO n = 1, upf(nt)%nwfc
             IF (upf(nt)%oc (n) >= 0.d0) THEN
                spdf = upf(nt)%els(n)
+               IF (spdf .eq. 'Xn' .and. n <= upf(nt)%gipaw_ncore_orbitals) THEN
+                  ! ATOMPAW stores labels in PP_GIPAW_CORE_ORBITAL
+                  spdf = upf(nt)%gipaw_core_orbital_el(n)
+               ENDIF
                l = upf(nt)%lchi (n)
                lmax_wfc = max (lmax_wfc, l )
                IF (lspinorb) THEN


### PR DESCRIPTION
For PAWs generated with ATOMPAW, orbital labels are only set in for GIPAW core orbitals (see Ce.GGA-PBE-paw-v1.0.UPF attached):
```<PP_GIPAW_CORE_ORBITAL.1 type="real" size="  1102" columns="3" index="1" label="1S" n="1" l="0">```

Attaching a complete example with the fix applies. Orbital labels are set in *.proj_up/*.proj_down files: https://github.com/QEF/q-e_schrodinger/files/1341891/example.zip
